### PR TITLE
README go install: include `@version`

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ written in nodejs. The goal is drop-in replacement of the nodejs version.
 ### Manually
 
 ```
-go install github.com/potoo0/configurable-http-proxy
+go install github.com/potoo0/configurable-http-proxy@latest
 ```
 
 ### Prebuilt


### PR DESCRIPTION
The current instructions fail:
```
$ go install github.com/potoo0/configurable-http-proxy
go: 'go install' requires a version when current directory is not in a module
        Try 'go install github.com/potoo0/configurable-http-proxy@latest' to install the latest version
```